### PR TITLE
[EGD-7993] Fix memory leak in system heap

### DIFF
--- a/re2/re2.h
+++ b/re2/re2.h
@@ -602,7 +602,8 @@ class RE2 {
     // If this happens too often, RE2 falls back on the NFA implementation.
 
     // For now, make the default budget something close to Code Search.
-    static const int kDefaultMaxMem = 8<<20;
+    // limit to 16kB Due to the small size of the system heap used when creating mutexes
+    static const int kDefaultMaxMem = 8<<11;
 
     enum Encoding {
       EncodingUTF8 = 1,


### PR DESCRIPTION
Reducing the memory allocation for re2,
which results in a change of the algorithm from DFA to NFA,
which consumes less resources.